### PR TITLE
Fix mongodb atlas connection uri

### DIFF
--- a/backend/config.env
+++ b/backend/config.env
@@ -1,5 +1,5 @@
 PORT=5000
-MONGODB_URI=mongodb://localhost:27017/pg_backend
+MONGODB_URI=mongodb+srv://Anandvaghela343:Anand%402511@cluster1.htxekoa.mongodb.net/PG_Finder
 JWT_SECRET=your_jwt_secret_key_here_change_in_production
 NODE_ENV=development
 


### PR DESCRIPTION
Update MongoDB URI to connect to Atlas, URL-encoding special characters in the password to resolve connection errors.

The previous MongoDB URI was for a local instance. When attempting to connect to MongoDB Atlas, the password contained an unencoded `@` symbol, leading to a "URI must include hostname, domain name, and tld" error. URL-encoding the `@` to `%40` resolves this parsing issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-d73c0cac-3218-4ed2-97eb-d3367d4d4ae4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d73c0cac-3218-4ed2-97eb-d3367d4d4ae4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

